### PR TITLE
Allow insertion of 'non-uniform' rowsets

### DIFF
--- a/src/datasource/DBDataSource.ts
+++ b/src/datasource/DBDataSource.ts
@@ -15,7 +15,7 @@ export type { DatabasePoolType } from 'slonik'
 
 import { LoaderFactory } from './loaders'
 import QueryBuilder, { QueryOptions as BuilderOptions } from './queries/QueryBuilder'
-import { CountQueryRowType, UpdateSet, ValueOrArray } from './queries/types'
+import { AllowSql, CountQueryRowType, UpdateSet, ValueOrArray } from './queries/types'
 
 export interface QueryOptions<TRowType, TResultType = TRowType> extends BuilderOptions<TRowType> {
   keyToColumn?: IdentifierNormalizerType;
@@ -120,7 +120,7 @@ export default class DBDataSource<
    * @param options Query options
    */
   protected async insert(
-    rows: TInsertType,
+    rows: AllowSql<TInsertType>,
     options?: QueryOptions<TRowType> & { expected?: undefined }
   ): Promise<TRowType>
 
@@ -130,7 +130,7 @@ export default class DBDataSource<
    * @param options Query options
    */
   protected async insert(
-    rows: Array<TInsertType>,
+    rows: Array<AllowSql<TInsertType>>,
     options?: QueryOptions<TRowType> & { expected?: undefined }
   ): Promise<readonly TRowType[]>
 
@@ -140,7 +140,7 @@ export default class DBDataSource<
    * @param options Query options
    */
   protected async insert(
-    rows: ValueOrArray<TInsertType>,
+    rows: ValueOrArray<AllowSql<TInsertType>>,
     options?: QueryOptions<TRowType> & { expected: 'one' }
   ): Promise<TRowType>
 
@@ -150,7 +150,7 @@ export default class DBDataSource<
    * @param options Query options
    */
   protected async insert(
-    rows: ValueOrArray<TInsertType>,
+    rows: ValueOrArray<AllowSql<TInsertType>>,
     options?: QueryOptions<TRowType> & { expected: 'maybeOne' }
   ): Promise<TRowType | null>
 
@@ -160,7 +160,7 @@ export default class DBDataSource<
    * @param options Query options
    */
   protected async insert(
-    rows: ValueOrArray<TInsertType>,
+    rows: ValueOrArray<AllowSql<TInsertType>>,
     options?: QueryOptions<TRowType> & { expected: 'any' | 'many' }
   ): Promise<readonly TRowType[]>
 
@@ -168,7 +168,7 @@ export default class DBDataSource<
    * Implementation
    */
   protected async insert(
-    rows: ValueOrArray<TInsertType>,
+    rows: ValueOrArray<AllowSql<TInsertType>>,
     options?: QueryOptions<TRowType>
   ): Promise<TRowType | readonly TRowType[] | null> {
     const query = this.builder.insert(rows, options)

--- a/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
@@ -445,6 +445,78 @@ Object {
 }
 `;
 
+exports[`QueryBuilder core query builders insert allows a single object with raw SQL values 1`] = `
+Object {
+  "sql": "
+      WITH \\"insert_rows\\" AS (
+        
+      INSERT INTO \\"any_table\\" (\\"id\\", \\"name\\")
+      VALUES ($1, DEFAULT)
+      RETURNING *
+    
+      ) SELECT *
+        FROM \\"insert_rows\\"
+        
+        
+        
+        
+    ",
+  "type": "SLONIK_TOKEN_SQL",
+  "values": Array [
+    1,
+  ],
+}
+`;
+
+exports[`QueryBuilder core query builders insert allows multiple objects with a mix of primitive and raw SQL values 1`] = `
+Object {
+  "sql": "
+      WITH \\"insert_rows\\" AS (
+        
+      INSERT INTO \\"any_table\\" (\\"id\\", \\"name\\")
+      VALUES ($1, $2), ($3, DEFAULT)
+      RETURNING *
+    
+      ) SELECT *
+        FROM \\"insert_rows\\"
+        
+        
+        
+        
+    ",
+  "type": "SLONIK_TOKEN_SQL",
+  "values": Array [
+    1,
+    "anything",
+    2,
+  ],
+}
+`;
+
+exports[`QueryBuilder core query builders insert allows multiple objects with raw SQL values 1`] = `
+Object {
+  "sql": "
+      WITH \\"insert_rows\\" AS (
+        
+      INSERT INTO \\"any_table\\" (\\"id\\", \\"name\\")
+      VALUES ($1, DEFAULT), ($2, DEFAULT)
+      RETURNING *
+    
+      ) SELECT *
+        FROM \\"insert_rows\\"
+        
+        
+        
+        
+    ",
+  "type": "SLONIK_TOKEN_SQL",
+  "values": Array [
+    1,
+    2,
+  ],
+}
+`;
+
 exports[`QueryBuilder core query builders insert correctly inserts Date objects as ISO8601 strings 1`] = `
 Object {
   "sql": "

--- a/src/datasource/__tests__/integration.test.ts
+++ b/src/datasource/__tests__/integration.test.ts
@@ -7,12 +7,14 @@ interface DummyRowType {
   id: number
   name: string
   code: string
+  with_default?: string
 }
 
 const columnTypes: Record<keyof DummyRowType, string> = {
   id: 'int8',
   name: 'citext',
   code: 'text',
+  with_default: 'text',
 }
 
 let pool: DatabasePoolType
@@ -35,7 +37,8 @@ beforeAll(async () => {
       CREATE TABLE "test_table" (
         "id" INTEGER PRIMARY KEY,
         "name" CITEXT NOT NULL,
-        "code" TEXT NOT NULL
+        "code" TEXT NOT NULL,
+        "with_default" TEXT NOT NULL DEFAULT 'anything'
       )
     `)
   })
@@ -82,9 +85,53 @@ describe(DBDataSource, () => {
         id: 2,
         code: 'CODE',
         name: 'Test Row',
+        with_default: 'asdf',
       }
       const result = await ds.testInsert(row)
       expect(result).toMatchObject(row)
+    })
+  })
+
+  it('can insert rows with raw sql and without', async () => {
+    const rows = [
+      {
+        id: 5,
+        code: 'A',
+        name: 'abc',
+        with_default: sql`DEFAULT`
+      },
+      {
+        id: 6,
+        code: 'B',
+        name: 'def',
+        with_default: 'value'
+      },
+      {
+        id: 7,
+        code: 'C',
+        name: 'ghi',
+      }
+    ]
+
+    const results = await ds.testInsert(rows)
+    expect(results).toHaveLength(3)
+    expect(results).toContainEqual({
+      id: 5,
+      code: 'A',
+      name: 'abc',
+      with_default: 'anything'
+    })
+    expect(results).toContainEqual({
+      id: 6,
+      code: 'B',
+      name: 'def',
+      with_default: 'value'
+    })
+    expect(results).toContainEqual({
+      id: 7,
+      code: 'C',
+      name: 'ghi',
+      with_default: 'anything'
     })
   })
 
@@ -93,6 +140,7 @@ describe(DBDataSource, () => {
       id: 2,
       code: 'CODE',
       name: 'Test Row',
+      with_default: 'asdf',
     }
 
     it('can select rows by various criteria', async () => {
@@ -118,11 +166,13 @@ describe(DBDataSource, () => {
         id: 10,
         code: 'any',
         name: 'any',
+        with_default: 'asdf',
       }
       const newRow2 = {
         id: 11,
         code: 'more',
         name: 'values',
+        with_default: 'asdf',
       }
       const result = await ds.testInsert([newRow1, newRow2])
       expect(result).toContainEqual(newRow1)
@@ -134,11 +184,13 @@ describe(DBDataSource, () => {
         id: 10,
         code: 'any',
         name: 'any',
+        with_default: 'asdf',
       }
       const newRow2 = {
         id: 11,
         code: 'more',
         name: 'values',
+        with_default: 'asdf',
       }
 
       await ds.testInsert([newRow1, newRow2])
@@ -163,11 +215,13 @@ describe(DBDataSource, () => {
         id: 10,
         code: 'any',
         name: 'any',
+        with_default: 'asdf',
       }
       const newRow2 = {
         id: 11,
         code: 'more',
         name: 'values',
+        with_default: 'asdf',
       }
 
       await ds.testInsert([newRow1, newRow2])
@@ -191,11 +245,13 @@ describe(DBDataSource, () => {
         id: 10,
         code: 'any',
         name: 'any',
+        with_default: 'asdf',
       }
       const newRow2 = {
         id: 11,
         code: 'more',
         name: 'values',
+        with_default: 'asdf',
       }
 
       await ds.testInsert([newRow1, newRow2])

--- a/src/datasource/__tests__/queries.test.ts
+++ b/src/datasource/__tests__/queries.test.ts
@@ -281,6 +281,43 @@ describe(QueryBuilder, () => {
           })
         ).toMatchSnapshot()
       })
+
+      it('allows a single object with raw SQL values', () => {
+        expect(builder.insert({
+          id: 1,
+          name: sql`DEFAULT`,
+        })).toMatchSnapshot()
+      })
+
+      it('allows multiple objects with raw SQL values', () => {
+        expect(
+          builder.insert([
+            {
+              id: 1,
+              name: sql`DEFAULT`,
+            },
+            {
+              id: 2,
+              name: sql`DEFAULT`,
+            }
+          ])
+        ).toMatchSnapshot()
+      })
+
+      it('allows multiple objects with a mix of primitive and raw SQL values', () => {
+        expect(
+          builder.insert([
+            {
+              id: 1,
+              name: 'anything',
+            },
+            {
+              id: 2,
+              name: sql`DEFAULT`,
+            }
+          ])
+        ).toMatchSnapshot()
+      })
     })
 
     describe('update', () => {

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -8,6 +8,7 @@ import {
 import { raw } from "slonik-sql-tag-raw"
 
 import {
+  AllowSql,
   ColumnList,
   Conditions,
   CountQueryRowType,
@@ -62,7 +63,7 @@ export default class QueryBuilder<TRowType, TInsertType extends { [K in keyof TR
     `
   }
 
-  public insert(rows: ValueOrArray<TInsertType>, options?: QueryOptions<TRowType>): TaggedTemplateLiteralInvocationType<TRowType> {
+  public insert(rows: ValueOrArray<AllowSql<TInsertType>>, options?: QueryOptions<TRowType>): TaggedTemplateLiteralInvocationType<TRowType> {
     if (!Array.isArray(rows)) {
       rows = [rows]
     }
@@ -270,7 +271,7 @@ export default class QueryBuilder<TRowType, TInsertType extends { [K in keyof TR
     return this.wrapCte('insert', insertQuery, options)
   }
 
-  protected insertNonUniform(rows: TInsertType[], options?: QueryOptions<TRowType>): TaggedTemplateLiteralInvocationType<TRowType> {
+  protected insertNonUniform(rows: AllowSql<TInsertType>[], options?: QueryOptions<TRowType>): TaggedTemplateLiteralInvocationType<TRowType> {
     const columns = this.rowsetKeys(rows)
     const columnExpression = sql.join(columns.map((c) => this.identifier(c, false)), sql`, `)
 
@@ -364,7 +365,7 @@ export default class QueryBuilder<TRowType, TInsertType extends { [K in keyof TR
     })
   }
 
-  private rowsetKeys(rows: TInsertType[]): Array<keyof TInsertType & keyof TRowType & string> {
+  private rowsetKeys(rows: AllowSql<TInsertType>[]): Array<keyof TInsertType & keyof TRowType & string> {
     const allKeys = rows.map(Object.keys)
     const keySet = new Set(...allKeys) as Set<keyof TInsertType & keyof TRowType & string>
     return Array.from(keySet)
@@ -384,7 +385,7 @@ export default class QueryBuilder<TRowType, TInsertType extends { [K in keyof TR
    * query parameters. Every uniform row could be included in a single parameter and
    * only non-uniform rows spread out as normal.
    */
-  private isUniformRowset(rowset: TInsertType[]): boolean {
+  private isUniformRowset(rowset: AllowSql<TInsertType>[]): rowset is TInsertType[] {
     // we can only parameterize the entire row if every row has only values that
     // are either primitive values (e.g. string, number) or are convertable
     // to primitive values (e.g. Date)

--- a/src/datasource/queries/types.ts
+++ b/src/datasource/queries/types.ts
@@ -61,6 +61,10 @@ export type ColumnList = ValueOrArray<ColumnListEntry>
 export type OrderTuple = [ColumnListEntry] | [ColumnListEntry, 'ASC' | 'DESC' | undefined | SqlSqlTokenType];
 export type OrderColumnList = ValueOrArray<ColumnListEntry | OrderTuple>;
 
+export type AllowSql<T> = {
+  [K in keyof T]?: T[K] | SqlTokenType
+}
+
 export interface CountQueryRowType {
   count: number
 }


### PR DESCRIPTION
* A **uniform** rowset is a list of one or more rows that satisfy two criteria:
    1. All rows contain **only** "primitive" values (e.g. strings) or values which can be converted to primtives (e.g. Dates)
    2. All rows contain the **exact** same set of keys
* A **non-uniform** rowset is any list of one or more rows that *does not* satisfy those criteria

With a uniform rowset, there will only be one query parameter (`N = 1`). With a non-uniform rowset, there will be up to `N = rows * columns` parameters. 

In theory we could partially parameterize a 'partially uniform' rowset. Such a rowset would have every row with the same keys but *some* rows may have non-primitive values. In such a 'partially uniform' rowset, the query would contain up to `N = 1 + (non-uniform rows) * columns` query parameters. Every uniform row could be included in a single parameter and only non-uniform rows spread out as normal.