### PR TITLE
fix: pass options through to loaders

### DIFF
--- a/src/datasource/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/integration.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DBDataSource when there is data in the table can set query options on a loader 1`] = `
+Array [
+  Object {
+    "code": "any",
+    "id": 20,
+    "jsonbTest": Object {
+      "a": 1,
+    },
+    "name": "any",
+    "tsTest": 2020-12-05T00:00:00.002Z,
+    "withDefault": "asdf",
+  },
+  Object {
+    "code": "any",
+    "id": 19,
+    "jsonbTest": Object {
+      "a": 1,
+    },
+    "name": "any",
+    "tsTest": 2020-12-05T00:00:00.001Z,
+    "withDefault": "asdf",
+  },
+]
+`;

--- a/src/datasource/__tests__/integration.test.ts
+++ b/src/datasource/__tests__/integration.test.ts
@@ -56,6 +56,10 @@ class TestDataSource extends DBDataSource<DummyRowType> {
   }
 
   public idLoader = this.loaders.create('id')
+  public codeLoader = this.loaders.create('code', {
+    multi: true,
+    orderBy: ['id', 'DESC'],
+  })
 
   // these functions are protected, so we're not normally able to access them
   public testInsert: TestDataSource['insert'] = this.insert
@@ -96,7 +100,6 @@ describe(DBDataSource, () => {
         jsonbTest: { a: 1 },
       }
       const result = await ds.testInsert(row)
-      console.log(result)
       expect(result).toMatchObject(row)
     })
   })
@@ -303,6 +306,30 @@ describe(DBDataSource, () => {
 
       const result = await ds.idLoader.load(newRow1.id)
       expect(result).toMatchObject(newRow1)
+    })
+
+    it('can set query options on a loader', async () => {
+      const row1: DummyRowType = {
+        id: 19,
+        code: 'any',
+        name: 'any',
+        withDefault: 'asdf',
+        tsTest: new Date('2020-12-05T00:00:00.001Z'),
+        jsonbTest: { a: 1 },
+      }
+      const row2: DummyRowType = {
+        id: 20,
+        code: 'any',
+        name: 'any',
+        withDefault: 'asdf',
+        tsTest: new Date('2020-12-05T00:00:00.002Z'),
+        jsonbTest: { a: 1 },
+      }
+
+      await ds.testInsert([row1, row2])
+
+      const result = await ds.codeLoader.load('any')
+      expect(result).toMatchSnapshot()
     })
   })
 })

--- a/src/datasource/loaders/LoaderFactory.ts
+++ b/src/datasource/loaders/LoaderFactory.ts
@@ -72,7 +72,7 @@ export default class LoaderFactory<TRowType> {
 
     return new DataLoader<TColType, TRowType[] | (TRowType | undefined)>(
       async (args: readonly TColType[]) => {
-        const data = await this.getData<TColumnName>(args, key, type)
+        const data = await this.getData<TColumnName>(args, key, type, options)
         callbackFn && data.forEach(callbackFn)
         return args.map((value) => {
           if (multi) {

--- a/src/datasource/loaders/types.ts
+++ b/src/datasource/loaders/types.ts
@@ -1,3 +1,5 @@
+import { QueryOptions } from '../queries/QueryBuilder'
+
 export type SearchableKeys<T, SearchableType = string | number | null> = {
   [K in keyof T]?: T extends { [_ in K]?: SearchableType } ? K : never
 }[keyof T]
@@ -6,7 +8,8 @@ export interface GetDataFunction<TRowType> {
   <TColumnName extends keyof TRowType & string>(
     args: Array<TRowType[TColumnName]> | ReadonlyArray<TRowType[TColumnName]>,
     column: TColumnName,
-    type: string
+    type: string,
+    options?: QueryOptions<TRowType>
   ): readonly TRowType[] | Promise<readonly TRowType[]>
 }
 
@@ -26,4 +29,4 @@ export type LoaderOptions<TRowType, TColumnName extends keyof TRowType> = {
     index: number,
     array: readonly TRowType[]
   ) => void
-}
+} & QueryOptions<TRowType>


### PR DESCRIPTION
query options were not being passed through to loaders, even though they ostensibly support that... 😬 