### PR TITLE
feat: count + groupBy = countGroup

### DIFF
--- a/src/datasource/DBDataSource.ts
+++ b/src/datasource/DBDataSource.ts
@@ -148,7 +148,10 @@ export default class DBDataSource<
   }
 
   public async count(
-    options?: Omit<QueryOptions<TRowType, CountQueryRowType>, 'expected'>
+    options?: Omit<
+      QueryOptions<TRowType, CountQueryRowType>,
+      'expected' | 'orderBy' | 'groupBy' | 'limit' | 'having'
+    >
   ): Promise<number> {
     const query = this.builder.count(options)
     const result = await this.query(query, {

--- a/src/datasource/DBDataSource.ts
+++ b/src/datasource/DBDataSource.ts
@@ -161,6 +161,23 @@ export default class DBDataSource<
     return result.count
   }
 
+  public async countGroup<TGroup extends Array<string & keyof TRowType>>(
+    groupColumns: TGroup & Array<keyof TRowType>,
+    options?: Omit<
+      QueryOptions<CountQueryRowType & { [K in TGroup[0]]: TRowType[K] }>,
+      'orderBy' | 'groupBy' | 'limit' | 'having' | 'expected'
+    >
+  ): Promise<
+    ReadonlyArray<CountQueryRowType & { [K in TGroup[0]]: TRowType[K] }>
+  > {
+    const query = this.builder.countGroup(groupColumns, options)
+    const result = await this.query(query, {
+      ...options,
+      expected: 'any',
+    })
+    return result
+  }
+
   /**
    * Insert a single row
    * @param rows Row data to insert

--- a/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
@@ -358,6 +358,34 @@ Object {
 }
 `;
 
+exports[`QueryBuilder core query builders countGroup can use where clauses 1`] = `
+Object {
+  "sql": "
+      SELECT \\"any_table\\".\\"nullable\\", \\"any_table\\".\\"optional\\", COUNT(*)
+      FROM \\"any_table\\"
+      WHERE (\\"any_table\\".\\"id\\" = $1)
+      GROUP BY \\"any_table\\".\\"nullable\\", \\"any_table\\".\\"optional\\"
+    ",
+  "type": "SLONIK_TOKEN_SQL",
+  "values": Array [
+    1,
+  ],
+}
+`;
+
+exports[`QueryBuilder core query builders countGroup creates a count query with a groupBy clause 1`] = `
+Object {
+  "sql": "
+      SELECT \\"any_table\\".\\"name\\", COUNT(*)
+      FROM \\"any_table\\"
+      
+      GROUP BY \\"any_table\\".\\"name\\"
+    ",
+  "type": "SLONIK_TOKEN_SQL",
+  "values": Array [],
+}
+`;
+
 exports[`QueryBuilder core query builders delete builds clauses correctly 1`] = `
 Object {
   "sql": "

--- a/src/datasource/__tests__/integration.test.ts
+++ b/src/datasource/__tests__/integration.test.ts
@@ -416,4 +416,18 @@ describe('DBDataSource', () => {
       expect(result).toMatchObject(row2)
     })
   })
+
+  describe('counting rows', () => {
+    it('can count all rows in the table', async () => {
+      const rows: DummyRowType[] = [
+        createRow({ id: 21 }),
+        createRow({ id: 22 }),
+        createRow({ id: 23 }),
+      ]
+      await ds.testInsert(rows)
+
+      const result = await ds.count()
+      expect(result).toEqual(rows.length)
+    })
+  })
 })

--- a/src/datasource/__tests__/integration.test.ts
+++ b/src/datasource/__tests__/integration.test.ts
@@ -441,7 +441,7 @@ describe('DBDataSource', () => {
       ]
       await ds.testInsert(rows)
 
-      const result = await ds.countGroup(['code'])
+      const [...result] = await ds.countGroup(['code'])
       expect(result.sort((a, b) => a.count - b.count)).toEqual(
         [
           { code: 'ONE', count: 1 },

--- a/src/datasource/__tests__/integration.test.ts
+++ b/src/datasource/__tests__/integration.test.ts
@@ -429,5 +429,26 @@ describe('DBDataSource', () => {
       const result = await ds.count()
       expect(result).toEqual(rows.length)
     })
+
+    it('can count rows in groups', async () => {
+      const rows: DummyRowType[] = [
+        createRow({ id: 24, code: 'ONE' }),
+        createRow({ id: 25, code: 'TWO' }),
+        createRow({ id: 26, code: 'TWO' }),
+        createRow({ id: 27, code: 'THREE' }),
+        createRow({ id: 28, code: 'THREE' }),
+        createRow({ id: 29, code: 'THREE' }),
+      ]
+      await ds.testInsert(rows)
+
+      const result = await ds.countGroup(['code'])
+      expect(result.sort((a, b) => a.count - b.count)).toEqual(
+        [
+          { code: 'ONE', count: 1 },
+          { code: 'TWO', count: 2 },
+          { code: 'THREE', count: 3 },
+        ].sort((a, b) => a.count - b.count)
+      )
+    })
   })
 })

--- a/src/datasource/__tests__/queries.test.ts
+++ b/src/datasource/__tests__/queries.test.ts
@@ -268,6 +268,18 @@ describe(QueryBuilder, () => {
       })
     })
 
+    describe('countGroup', () => {
+      it('creates a count query with a groupBy clause', () => {
+        expect(builder.countGroup(['name'])).toMatchSnapshot()
+      })
+
+      it('can use where clauses', () => {
+        expect(
+          builder.countGroup(['nullable', 'optional'], { where: { id: 1 } })
+        ).toMatchSnapshot()
+      })
+    })
+
     describe('insert', () => {
       it('accepts a basic object', () => {
         expect(

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -168,6 +168,27 @@ export default class QueryBuilder<
     `
   }
 
+  public countGroup<TGroup extends Array<string & keyof TRowType>>(
+    groupColumns: TGroup & Array<keyof TRowType>,
+    options?: Omit<
+      QueryOptions<TRowType>,
+      'orderBy' | 'groupBy' | 'limit' | 'having'
+    >
+  ): TaggedTemplateLiteralInvocationType<
+    CountQueryRowType & { [K in TGroup[0]]: TRowType[K] }
+  > {
+    options = this.getOptions(options)
+
+    const columns = this.columnList(groupColumns)
+
+    return sql<CountQueryRowType & { [K in TGroup[0]]: TRowType[K] }>`
+      SELECT ${sql.join(columns, sql`, `)}, COUNT(*)
+      FROM ${this.identifier()}
+      ${options.where ? this.where(options.where) : EMPTY}
+      ${this.groupBy(groupColumns)}
+    `
+  }
+
   /* Public clause builders */
 
   /**


### PR DESCRIPTION
Adds a new method to `DBDataSource` -- `countGroup`. In addition to the count for each group, it will also select each of the columns included in the `GROUP BY` clause.

The `groupBy` option was omitted from `count` because what the behavior should be wasn't immediately clear, and if it were supported, the types would be complex and difficult to understand.

By separating the grouping functionality into a separate method, the types are simplified and the behavior is clear.