### PR TITLE
feat: finders overhaul

### DIFF
--- a/src/datasource/DBDataSource.ts
+++ b/src/datasource/DBDataSource.ts
@@ -13,7 +13,7 @@ import { DataSource, DataSourceConfig } from 'apollo-datasource'
 
 export type { DatabasePoolType } from 'slonik'
 
-import { LoaderFactory } from './loaders'
+import { FinderFactory, LoaderFactory } from './loaders'
 import QueryBuilder, {
   QueryOptions as BuilderOptions,
   SelectOptions,
@@ -78,6 +78,15 @@ export default class DBDataSource<
     }
 
     return this._loaders
+  }
+
+  private _finders?: FinderFactory<TRowType>
+  protected get finders(): FinderFactory<TRowType> {
+    if (!this._finders) {
+      this._finders = new FinderFactory()
+    }
+
+    return this._finders
   }
 
   private _builder?: QueryBuilder<TRowType, TInsertType>

--- a/src/datasource/__tests__/__snapshots__/finders.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/finders.test.ts.snap
@@ -1,21 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LoaderFactory it can infer \`multi\` from an extended data loader gets all matching results 1`] = `
-Array [
-  Object {
-    "code": "abc",
-    "id": 1,
-    "name": "aaa",
-  },
-  Object {
-    "code": "abc",
-    "id": 7,
-    "name": "AAA",
-  },
-]
-`;
-
-exports[`LoaderFactory multi: false returns the first matching result 1`] = `
+exports[`LoaderFactory create multi: false returns the first matching result 1`] = `
 Object {
   "code": "abc",
   "id": 1,
@@ -23,7 +8,7 @@ Object {
 }
 `;
 
-exports[`LoaderFactory multi: true gets all matching results 1`] = `
+exports[`LoaderFactory create multi: true gets all matching results 1`] = `
 Array [
   Object {
     "code": "abc",
@@ -38,7 +23,7 @@ Array [
 ]
 `;
 
-exports[`LoaderFactory when inferring multi from an extended loader gets all matching results 1`] = `
+exports[`LoaderFactory create when inferring multi from an extended loader gets all matching results 1`] = `
 Array [
   Object {
     "code": "abc",

--- a/src/datasource/__tests__/__snapshots__/finders.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/finders.test.ts.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LoaderFactory it can infer \`multi\` from an extended data loader gets all matching results 1`] = `
+Array [
+  Object {
+    "code": "abc",
+    "id": 1,
+    "name": "aaa",
+  },
+  Object {
+    "code": "abc",
+    "id": 7,
+    "name": "AAA",
+  },
+]
+`;
+
 exports[`LoaderFactory multi: false returns the first matching result 1`] = `
 Object {
   "code": "abc",
@@ -9,6 +24,21 @@ Object {
 `;
 
 exports[`LoaderFactory multi: true gets all matching results 1`] = `
+Array [
+  Object {
+    "code": "abc",
+    "id": 1,
+    "name": "aaa",
+  },
+  Object {
+    "code": "abc",
+    "id": 7,
+    "name": "AAA",
+  },
+]
+`;
+
+exports[`LoaderFactory when inferring multi from an extended loader gets all matching results 1`] = `
 Array [
   Object {
     "code": "abc",

--- a/src/datasource/__tests__/__snapshots__/finders.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/finders.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoaderFactory multi: false returns the first matching result 1`] = `
+Object {
+  "code": "abc",
+  "id": 1,
+  "name": "aaa",
+}
+`;
+
+exports[`LoaderFactory multi: true gets all matching results 1`] = `
+Array [
+  Object {
+    "code": "abc",
+    "id": 1,
+    "name": "aaa",
+  },
+  Object {
+    "code": "abc",
+    "id": 7,
+    "name": "AAA",
+  },
+]
+`;

--- a/src/datasource/__tests__/finders.test.ts
+++ b/src/datasource/__tests__/finders.test.ts
@@ -37,42 +37,44 @@ describe(LoaderFactory, () => {
   const loaders = new LoaderFactory<DummyRowType>(dummyBatchFn, { columnTypes })
   const finders = new FinderFactory<DummyRowType>()
 
-  describe('multi: false', () => {
-    const loader = loaders.create('id')
-    const finder = finders.create(loader)
+  describe('create', () => {
+    describe('multi: false', () => {
+      const loader = loaders.create('id')
+      const finder = finders.create(loader)
 
-    it('returns the first matching result', async () => {
-      expect(await finder(1)).toMatchSnapshot()
+      it('returns the first matching result', async () => {
+        expect(await finder(1)).toMatchSnapshot()
+      })
+
+      it('returns null with no matching results', async () => {
+        expect(await finder(-Infinity)).toBeNull()
+      })
     })
 
-    it('returns null with no matching results', async () => {
-      expect(await finder(-Infinity)).toBeNull()
-    })
-  })
+    describe('multi: true', () => {
+      const loader = loaders.create('code', { multi: true })
+      const finder = finders.create(loader, { multi: true })
 
-  describe('multi: true', () => {
-    const loader = loaders.create('code', { multi: true })
-    const finder = finders.create(loader, { multi: true })
+      it('gets all matching results', async () => {
+        expect(await finder('abc')).toMatchSnapshot()
+      })
 
-    it('gets all matching results', async () => {
-      expect(await finder('abc')).toMatchSnapshot()
-    })
-
-    it('returns an empty array with no matching results', async () => {
-      expect(await finder('any value with no match')).toHaveLength(0)
-    })
-  })
-
-  describe('when inferring multi from an extended loader', () => {
-    const loader = loaders.create('code', { multi: true })
-    const finder = finders.create(loader)
-
-    it('gets all matching results', async () => {
-      expect(await finder('abc')).toMatchSnapshot()
+      it('returns an empty array with no matching results', async () => {
+        expect(await finder('any value with no match')).toHaveLength(0)
+      })
     })
 
-    it('returns an empty array with no matching results', async () => {
-      expect(await finder('any value with no match')).toHaveLength(0)
+    describe('when inferring multi from an extended loader', () => {
+      const loader = loaders.create('code', { multi: true })
+      const finder = finders.create(loader)
+
+      it('gets all matching results', async () => {
+        expect(await finder('abc')).toMatchSnapshot()
+      })
+
+      it('returns an empty array with no matching results', async () => {
+        expect(await finder('any value with no match')).toHaveLength(0)
+      })
     })
   })
 })

--- a/src/datasource/__tests__/finders.test.ts
+++ b/src/datasource/__tests__/finders.test.ts
@@ -62,4 +62,17 @@ describe(LoaderFactory, () => {
       expect(await finder('any value with no match')).toHaveLength(0)
     })
   })
+
+  describe('when inferring multi from an extended loader', () => {
+    const loader = loaders.create('code', { multi: true })
+    const finder = finders.create(loader)
+
+    it('gets all matching results', async () => {
+      expect(await finder('abc')).toMatchSnapshot()
+    })
+
+    it('returns an empty array with no matching results', async () => {
+      expect(await finder('any value with no match')).toHaveLength(0)
+    })
+  })
 })

--- a/src/datasource/__tests__/finders.test.ts
+++ b/src/datasource/__tests__/finders.test.ts
@@ -1,0 +1,65 @@
+import { FinderFactory, LoaderFactory } from '../loaders'
+import { GetDataFunction } from '../loaders/types'
+
+interface DummyRowType {
+  id: number
+  name: string
+  code: string
+}
+
+const columnTypes: Record<keyof DummyRowType, string> = {
+  id: 'anything',
+  name: 'anything',
+  code: 'anything',
+}
+
+describe(LoaderFactory, () => {
+  const dummyBatchFn: GetDataFunction<DummyRowType> = async (): Promise<
+    DummyRowType[]
+  > => {
+    return [
+      { id: 1, name: 'aaa', code: 'abc' },
+      { id: 2, name: 'bbb', code: 'def' },
+      { id: 3, name: 'Aaa', code: 'ghi' },
+      { id: 4, name: 'Bbb', code: 'ABC' },
+      { id: 5, name: 'AAa', code: 'DEF' },
+      { id: 6, name: 'BBb', code: 'GHI' },
+      { id: 7, name: 'AAA', code: 'abc' },
+      { id: 8, name: 'BBB', code: 'def' },
+      { id: 9, name: 'zzz', code: 'ghi' },
+      { id: 10, name: 'ccc', code: 'ABC' },
+      { id: 11, name: 'Ccc', code: 'DEF' },
+      { id: 12, name: 'CCc', code: 'GHI' },
+      { id: 13, name: 'CCC', code: 'zzz' },
+    ]
+  }
+
+  const loaders = new LoaderFactory<DummyRowType>(dummyBatchFn, { columnTypes })
+  const finders = new FinderFactory<DummyRowType>()
+
+  describe('multi: false', () => {
+    const loader = loaders.create('id')
+    const finder = finders.create(loader)
+
+    it('returns the first matching result', async () => {
+      expect(await finder(1)).toMatchSnapshot()
+    })
+
+    it('returns null with no matching results', async () => {
+      expect(await finder(-Infinity)).toBeNull()
+    })
+  })
+
+  describe('multi: true', () => {
+    const loader = loaders.create('code', { multi: true })
+    const finder = finders.create(loader, { multi: true })
+
+    it('gets all matching results', async () => {
+      expect(await finder('abc')).toMatchSnapshot()
+    })
+
+    it('returns an empty array with no matching results', async () => {
+      expect(await finder('any value with no match')).toHaveLength(0)
+    })
+  })
+})

--- a/src/datasource/loaders/FinderFactory.ts
+++ b/src/datasource/loaders/FinderFactory.ts
@@ -1,0 +1,48 @@
+import DataLoader from 'dataloader'
+
+import { FinderOptions } from './types'
+
+export interface FinderFunction<TInput, TRowType> {
+  (value: TInput): Promise<TRowType>
+}
+
+export default class FinderFactory<TRowType> {
+  public create<TInput>(
+    loader: DataLoader<TInput, TRowType[]>,
+    options: FinderOptions & { multi: true }
+  ): FinderFunction<TInput, TRowType[]>
+  public create<TInput>(
+    loader: DataLoader<TInput, TRowType | undefined>,
+    options?: FinderOptions & { multi?: false }
+  ): FinderFunction<TInput, TRowType | null>
+  public create<TInput>(
+    loader: DataLoader<TInput, TRowType | TRowType[] | undefined>,
+    options?: FinderOptions
+  ): FinderFunction<TInput, TRowType[] | TRowType | null> {
+    const { multi = false } = options || {}
+
+    if (multi === true) {
+      return async (value: TInput): Promise<TRowType[]> => {
+        const result = await loader.load(value)
+        if (!result) {
+          return []
+        }
+        if (!Array.isArray(result)) {
+          return [result]
+        }
+        return result
+      }
+    }
+
+    return async (value: TInput): Promise<TRowType | null> => {
+      const result = await loader.load(value)
+      if (!result) {
+        return null
+      }
+      if (Array.isArray(result)) {
+        return result[0]
+      }
+      return result
+    }
+  }
+}

--- a/src/datasource/loaders/index.ts
+++ b/src/datasource/loaders/index.ts
@@ -1,1 +1,2 @@
 export { default as LoaderFactory } from './LoaderFactory'
+export { default as FinderFactory } from './FinderFactory'

--- a/src/datasource/loaders/types.ts
+++ b/src/datasource/loaders/types.ts
@@ -31,3 +31,7 @@ export type LoaderOptions<TRowType, TColumnName extends keyof TRowType> = {
     array: readonly TRowType[]
   ) => void
 } & QueryOptions<TRowType>
+
+export type FinderOptions = {
+  multi?: boolean
+}


### PR DESCRIPTION
the `createFinder` and `createMultiFinder` methods have been deprecated for a while, but there was no API to replace them. this is that API, and adds some convenience around `LoaderFactory`-generated loaders