### PR TITLE
fix(insert): return array when given an array of one input

### DIFF
--- a/src/datasource/DBDataSource.ts
+++ b/src/datasource/DBDataSource.ts
@@ -245,7 +245,7 @@ export default class DBDataSource<
     options: QueryOptions<TRowType> = {}
   ): Promise<TRowType | readonly TRowType[] | null> {
     if (!options.expected) {
-      options.expected = !isArray(rows) || rows.length === 1 ? 'one' : 'many'
+      options.expected = !isArray(rows) ? 'one' : 'many'
     }
 
     if (isArray(rows) && rows.length === 0) {

--- a/src/datasource/__tests__/integration.test.ts
+++ b/src/datasource/__tests__/integration.test.ts
@@ -161,6 +161,21 @@ describe('DBDataSource', () => {
     })
   })
 
+  describe('when given an array with one input', () => {
+    it('returns an array of results', async () => {
+      const row1: DummyRowType = createRow({
+        id: 99,
+        code: 'A',
+        name: 'abc',
+        tsTest: new Date('2020-12-05T00:00:00.001Z'),
+        jsonbTest: { a: 1 },
+      })
+
+      const results = await ds.testInsert([row1])
+      expect(Array.isArray(results)).toBe(true)
+    })
+  })
+
   it('can insert rows with columns of arbitrary case', async () => {
     const row: DummyRowType = createRow({
       id: 8,


### PR DESCRIPTION
### Before:
The types for `insert` suggested that, given an array with one element, the method would return an array of inserted rows. However, it actually returned an object, leading to errors.

### After:
`insert` actually returns an array of results when given an array with a single row input