### PR TITLE
fix(generator): use case-insensitive collations

### DIFF
--- a/src/generator/database/SchemaInfo.ts
+++ b/src/generator/database/SchemaInfo.ts
@@ -41,7 +41,7 @@ export default class SchemaInfo {
             ) AS "comment"
       FROM information_schema.tables
       WHERE table_schema = ${this.name}
-      ORDER BY table_name ASC
+      ORDER BY lower(table_name) ASC
     `
   }
 
@@ -88,7 +88,7 @@ export default class SchemaInfo {
         c.table_schema = ${this.name} AND
         c.table_name = ${table}
       )
-      ORDER BY c.column_name
+      ORDER BY lower(c.column_name)
     `
   }
 
@@ -111,7 +111,7 @@ export default class SchemaInfo {
       GROUP BY n.nspname
              , t.typname
              , e.enumtypid
-      ORDER BY t.typname
+      ORDER BY lower(t.typname)
     `
   }
 


### PR DESCRIPTION
This changes the schema info queries to order by name in a
case-insensitive manner by lowercasing names in the order clause.

For better or worse, PostgreSQL uses the operating system's
implementation of collation, which leads to inconsistencies in ordering
across different operating systems.

This means that generated database types are not idempotent, leading to
issues in CI.

By lowercasing the names before ordering, we avoid the issue of
case-sensitive, operating system-dependent collations.

See-Also: https://dba.stackexchange.com/a/131471/134777