### PR TITLE
fix(generator): use case-sensitive collations

### DIFF
--- a/src/generator/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/generator/__tests__/__snapshots__/integration.test.ts.snap
@@ -26,6 +26,8 @@ export const TestTableOrder$Types: Record<keyof TestTableOrder, string> = {
 };
 export interface TestTableStandard<TJsonbTest = SerializableValueType> {
     arr_test: string[] | null;
+    caseTest_upper: string | null;
+    casetest_lower: string | null;
     domain_test: string | null;
     enum_arr_test: TestTypeEnum[] | null;
     enum_test: TestTypeEnum;
@@ -34,6 +36,8 @@ export interface TestTableStandard<TJsonbTest = SerializableValueType> {
 }
 export interface TestTableStandard$Insert<TJsonbTest = SerializableValueType> {
     arr_test?: string[] | null;
+    caseTest_upper?: string | null;
+    casetest_lower?: string | null;
     domain_test?: string | null;
     enum_arr_test?: TestTypeEnum[] | null;
     enum_test: TestTypeEnum;
@@ -42,6 +46,8 @@ export interface TestTableStandard$Insert<TJsonbTest = SerializableValueType> {
 }
 export const TestTableStandard$Types: Record<keyof TestTableStandard, string> = {
     arr_test: \\"text\\",
+    caseTest_upper: \\"text\\",
+    casetest_lower: \\"text\\",
     domain_test: \\"text\\",
     enum_arr_test: \\"test_type_enum\\",
     enum_test: \\"test_type_enum\\",

--- a/src/generator/__tests__/integration.test.ts
+++ b/src/generator/__tests__/integration.test.ts
@@ -40,7 +40,9 @@ beforeAll(async () => {
       domain_test TEST_TYPE_DOMAIN,
       enum_test TEST_TYPE_ENUM NOT NULL,
       enum_arr_test TEST_TYPE_ENUM[],
-      jsonb_test JSONB
+      jsonb_test JSONB,
+      "casetest_lower" TEXT,
+      "caseTest_upper" TEXT
     )
   `)
   await pool.query(sql`

--- a/src/generator/database/SchemaInfo.ts
+++ b/src/generator/database/SchemaInfo.ts
@@ -41,7 +41,7 @@ export default class SchemaInfo {
             ) AS "comment"
       FROM information_schema.tables
       WHERE table_schema = ${this.name}
-      ORDER BY lower(table_name) ASC
+      ORDER BY table_name::text COLLATE "C" ASC
     `
   }
 
@@ -88,7 +88,7 @@ export default class SchemaInfo {
         c.table_schema = ${this.name} AND
         c.table_name = ${table}
       )
-      ORDER BY lower(c.column_name)
+      ORDER BY c.column_name::text COLLATE "C" ASC
     `
   }
 
@@ -111,7 +111,7 @@ export default class SchemaInfo {
       GROUP BY n.nspname
              , t.typname
              , e.enumtypid
-      ORDER BY lower(t.typname)
+      ORDER BY t.typname::text COLLATE "C" ASC
     `
   }
 


### PR DESCRIPTION
trying to make it case-insensitive didn't work, so instead we'll just go
with the C collation, which should lead to cross-platform idempotency in
ordering