### PR TITLE
feat: multi-column loaders

### DIFF
--- a/src/datasource/DBDataSource.ts
+++ b/src/datasource/DBDataSource.ts
@@ -69,10 +69,14 @@ export default class DBDataSource<
   private _loaders?: LoaderFactory<TRowType>
   protected get loaders(): LoaderFactory<TRowType> {
     if (!this._loaders) {
-      this._loaders = new LoaderFactory(this.getDataByColumn.bind(this), {
-        ...this.normalizers,
-        columnTypes: this.columnTypes,
-      })
+      this._loaders = new LoaderFactory(
+        this.getDataByColumn.bind(this),
+        this.getDataByMultipleColumns.bind(this),
+        {
+          ...this.normalizers,
+          columnTypes: this.columnTypes,
+        }
+      )
     }
 
     return this._loaders
@@ -473,6 +477,21 @@ export default class DBDataSource<
         ...options?.where,
       },
     })
+  }
+
+  private async getDataByMultipleColumns<
+    TColumnNames extends Array<keyof TRowType & string>
+  >(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _args: ReadonlyArray<Record<TColumnNames[0], TRowType[TColumnNames[0]]>>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _columns: TColumnNames,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _types: string[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options?: QueryOptions<TRowType>
+  ): Promise<readonly TRowType[]> {
+    return []
   }
 
   private transformResult<TInput, TOutput>(input: TInput): TOutput {

--- a/src/datasource/DBDataSource.ts
+++ b/src/datasource/DBDataSource.ts
@@ -479,19 +479,23 @@ export default class DBDataSource<
     })
   }
 
-  private async getDataByMultipleColumns<
-    TColumnNames extends Array<keyof TRowType & string>
+  protected async getDataByMultipleColumns<
+    TColumnNames extends Array<keyof TRowType & string>,
+    TArgs extends { [K in TColumnNames[0]]: TRowType[K] }
   >(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _args: ReadonlyArray<Record<TColumnNames[0], TRowType[TColumnNames[0]]>>,
+    args: ReadonlyArray<TArgs>,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _columns: TColumnNames,
+    columns: TColumnNames,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _types: string[],
+    types: string[],
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _options?: QueryOptions<TRowType>
+    options?: QueryOptions<TRowType> & SelectOptions
   ): Promise<readonly TRowType[]> {
-    return []
+    return await this.query(
+      this.builder.multiColumnBatchGet(args, columns, types, options),
+      { expected: 'any' }
+    )
   }
 
   private transformResult<TInput, TOutput>(input: TInput): TOutput {

--- a/src/datasource/__tests__/DBDataSource.test.ts
+++ b/src/datasource/__tests__/DBDataSource.test.ts
@@ -1,7 +1,6 @@
 import { DBDataSource } from '..'
 import { createMockPool } from '../../testing'
 import { LoaderFactory } from '../loaders'
-import { GetDataFunction } from '../loaders/types'
 
 interface DummyRowType {
   id: number
@@ -16,9 +15,7 @@ const columnTypes: Record<keyof DummyRowType, string> = {
 }
 
 describe(DBDataSource, () => {
-  const dummyBatchFn: GetDataFunction<DummyRowType> = async (): Promise<
-    DummyRowType[]
-  > => {
+  const dummyBatchFn = async (): Promise<DummyRowType[]> => {
     return [
       { id: 1, name: 'aaa', code: 'abc' },
       { id: 2, name: 'bbb', code: 'def' },
@@ -36,7 +33,9 @@ describe(DBDataSource, () => {
     ]
   }
 
-  const factory = new LoaderFactory<DummyRowType>(dummyBatchFn, { columnTypes })
+  const factory = new LoaderFactory<DummyRowType>(dummyBatchFn, dummyBatchFn, {
+    columnTypes,
+  })
 
   class DummyDBDataSource extends DBDataSource<DummyRowType> {
     constructor() {

--- a/src/datasource/__tests__/__snapshots__/integration.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/integration.test.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DBDataSource multi loaders can query with multi-column loaders 1`] = `
+Array [
+  Object {
+    "code": "secret",
+    "dateTest": 2021-04-19T00:00:00.000Z,
+    "id": 30,
+    "jsonbTest": Object {
+      "a": 1,
+    },
+    "name": "hello",
+    "nullable": null,
+    "tsTest": 2020-12-05T00:00:00.000Z,
+    "withDefault": "anything",
+  },
+]
+`;
+
 exports[`DBDataSource when there is data in the table can set query options on a loader 1`] = `
 Array [
   Object {

--- a/src/datasource/__tests__/__snapshots__/loaders.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/loaders.test.ts.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`LoaderFactory createMulti can create loaders with multiple columns 1`] = `
+Array [
+  Object {
+    "code": "ABC",
+    "id": 10,
+    "name": "ccc",
+  },
+]
+`;
+
+exports[`LoaderFactory createMulti properly batches queries 1`] = `
+Array [
+  Array [
+    Object {
+      "code": "ABC",
+      "id": 10,
+      "name": "ccc",
+    },
+  ],
+  Array [
+    Object {
+      "code": "DEF",
+      "id": 5,
+      "name": "AAa",
+    },
+  ],
+]
+`;
+
 exports[`LoaderFactory multi: false, ignoreCase: false is able to load many items 1`] = `
 Array [
   Object {

--- a/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
@@ -583,12 +583,9 @@ Object {
       SELECT \\"any_table\\".*
       FROM \\"any_table\\",
       
-      LATERAL (
-        SELECT *
-        FROM json_populate_recordset(
-          null::\\"any_table\\",
-          $1
-        )
+      json_populate_recordset(
+        null::\\"any_table\\",
+        $1
       ) AS \\"any_table_conditions\\"
     
       WHERE \\"any_table\\".\\"id\\"::\\"integer\\" = \\"any_table_conditions\\".\\"id\\"::\\"integer\\" AND \\"any_table\\".\\"name\\"::\\"text\\" = \\"any_table_conditions\\".\\"name\\"::\\"text\\"

--- a/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
+++ b/src/datasource/__tests__/__snapshots__/queries.test.ts.snap
@@ -577,6 +577,33 @@ Object {
 }
 `;
 
+exports[`QueryBuilder core query builders multiColumnBatchGet builds the query correctly 1`] = `
+Object {
+  "sql": "
+      SELECT \\"any_table\\".*
+      FROM \\"any_table\\",
+      
+      LATERAL (
+        SELECT *
+        FROM json_populate_recordset(
+          null::\\"any_table\\",
+          $1
+        )
+      ) AS \\"any_table_conditions\\"
+    
+      WHERE \\"any_table\\".\\"id\\"::\\"integer\\" = \\"any_table_conditions\\".\\"id\\"::\\"integer\\" AND \\"any_table\\".\\"name\\"::\\"text\\" = \\"any_table_conditions\\".\\"name\\"::\\"text\\"
+      
+      
+      
+      
+    ",
+  "type": "SLONIK_TOKEN_SQL",
+  "values": Array [
+    "[{\\"id\\":1,\\"name\\":\\"asdf\\"},{\\"id\\":2,\\"name\\":\\"blah\\"}]",
+  ],
+}
+`;
+
 exports[`QueryBuilder core query builders select can select for update 1`] = `
 Object {
   "sql": "

--- a/src/datasource/__tests__/finders.test.ts
+++ b/src/datasource/__tests__/finders.test.ts
@@ -1,5 +1,4 @@
 import { FinderFactory, LoaderFactory } from '../loaders'
-import { GetDataFunction } from '../loaders/types'
 
 interface DummyRowType {
   id: number
@@ -14,9 +13,7 @@ const columnTypes: Record<keyof DummyRowType, string> = {
 }
 
 describe(LoaderFactory, () => {
-  const dummyBatchFn: GetDataFunction<DummyRowType> = async (): Promise<
-    DummyRowType[]
-  > => {
+  const dummyBatchFn = async (): Promise<DummyRowType[]> => {
     return [
       { id: 1, name: 'aaa', code: 'abc' },
       { id: 2, name: 'bbb', code: 'def' },
@@ -34,7 +31,9 @@ describe(LoaderFactory, () => {
     ]
   }
 
-  const loaders = new LoaderFactory<DummyRowType>(dummyBatchFn, { columnTypes })
+  const loaders = new LoaderFactory<DummyRowType>(dummyBatchFn, dummyBatchFn, {
+    columnTypes,
+  })
   const finders = new FinderFactory<DummyRowType>()
 
   describe('create', () => {

--- a/src/datasource/__tests__/integration.test.ts
+++ b/src/datasource/__tests__/integration.test.ts
@@ -84,6 +84,10 @@ class TestDataSource extends DBDataSource<DummyRowType> {
     orderBy: ['id', 'DESC'],
   })
 
+  public idAndCodeLoader = this.loaders.createMulti(['name', 'code'], {
+    multi: true,
+  })
+
   // these functions are protected, so we're not normally able to access them
   public testGet: TestDataSource['get'] = this.get
   public testCount: TestDataSource['count'] = this.count
@@ -474,6 +478,20 @@ describe('DBDataSource', () => {
           { code: 'THREE', count: 3 },
         ].sort((a, b) => a.count - b.count)
       )
+    })
+  })
+
+  describe('multi loaders', () => {
+    it('can query with multi-column loaders', async () => {
+      const rows: DummyRowType[] = [
+        createRow({ id: 30, name: 'hello', code: 'secret' }),
+        createRow({ id: 31, name: 'noway', code: 'secret' }),
+      ]
+      await ds.testInsert(rows)
+
+      expect(
+        await ds.idAndCodeLoader.load({ name: 'hello', code: 'secret' })
+      ).toMatchSnapshot()
     })
   })
 })

--- a/src/datasource/__tests__/loaders.test.ts
+++ b/src/datasource/__tests__/loaders.test.ts
@@ -129,6 +129,38 @@ describe(LoaderFactory, () => {
       expect(await loader.load('zzz')).toMatchObject(dummyRow)
     })
   })
+
+  describe('with multiple columns', () => {
+    it('can create loaders with multiple columns', async () => {
+      const loader = factory.create(['name', 'code'], {
+        multi: true,
+        ignoreCase: true,
+      })
+      expect(await loader.load({ name: 'ccc', code: 'abc' })).toMatchSnapshot()
+    })
+
+    it('properly batches queries', async () => {
+      const loader = factory.create(['name', 'code'], {
+        multi: true,
+        ignoreCase: true,
+      })
+      expect(
+        await Promise.all([
+          loader.load({ name: 'ccc', code: 'abc' }),
+          loader.load({ name: 'aaa', code: 'def' }),
+        ])
+      ).toMatchSnapshot()
+    })
+
+    it('properly caches queries', async () => {
+      const dummyRow = { id: 999, name: 'zzz', code: 'zzz' }
+      const getData = jest.fn(() => [dummyRow])
+      const loader = factory.create(['name', 'code'], { getData })
+      await loader.load({ name: 'zzz', code: 'zzz' })
+      await loader.load({ name: 'zzz', code: 'zzz' })
+      expect(getData).toBeCalledTimes(1)
+    })
+  })
 })
 
 describe(match, () => {

--- a/src/datasource/__tests__/loaders.test.ts
+++ b/src/datasource/__tests__/loaders.test.ts
@@ -1,5 +1,4 @@
 import { LoaderFactory } from '../loaders'
-import { GetDataFunction } from '../loaders/types'
 import { match } from '../loaders/utils'
 
 interface DummyRowType {
@@ -15,9 +14,7 @@ const columnTypes: Record<keyof DummyRowType, string> = {
 }
 
 describe(LoaderFactory, () => {
-  const dummyBatchFn: GetDataFunction<DummyRowType> = async (): Promise<
-    DummyRowType[]
-  > => {
+  const dummyBatchFn = async (): Promise<DummyRowType[]> => {
     return [
       { id: 1, name: 'aaa', code: 'abc' },
       { id: 2, name: 'bbb', code: 'def' },
@@ -35,7 +32,9 @@ describe(LoaderFactory, () => {
     ]
   }
 
-  const factory = new LoaderFactory<DummyRowType>(dummyBatchFn, { columnTypes })
+  const factory = new LoaderFactory<DummyRowType>(dummyBatchFn, dummyBatchFn, {
+    columnTypes,
+  })
 
   describe('multi: false, ignoreCase: false', () => {
     const loader = factory.create('id', 'any', {
@@ -130,9 +129,9 @@ describe(LoaderFactory, () => {
     })
   })
 
-  describe('with multiple columns', () => {
+  describe('createMulti', () => {
     it('can create loaders with multiple columns', async () => {
-      const loader = factory.create(['name', 'code'], {
+      const loader = factory.createMulti(['name', 'code'], {
         multi: true,
         ignoreCase: true,
       })
@@ -140,7 +139,7 @@ describe(LoaderFactory, () => {
     })
 
     it('properly batches queries', async () => {
-      const loader = factory.create(['name', 'code'], {
+      const loader = factory.createMulti(['name', 'code'], {
         multi: true,
         ignoreCase: true,
       })
@@ -155,10 +154,30 @@ describe(LoaderFactory, () => {
     it('properly caches queries', async () => {
       const dummyRow = { id: 999, name: 'zzz', code: 'zzz' }
       const getData = jest.fn(() => [dummyRow])
-      const loader = factory.create(['name', 'code'], { getData })
+      const loader = factory.createMulti(['name', 'code'], { getData })
       await loader.load({ name: 'zzz', code: 'zzz' })
       await loader.load({ name: 'zzz', code: 'zzz' })
       expect(getData).toBeCalledTimes(1)
+    })
+
+    it('expects columnTypes of the same length if given', () => {
+      expect(() => factory.createMulti(['name', 'code'])).not.toThrowError()
+
+      expect(() =>
+        factory.createMulti(['name', 'code'], ['onlyType1'])
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Same number of types and keys must be provided"`
+      )
+
+      expect(() =>
+        factory.createMulti(['name', 'code'], ['type1', 'type2'])
+      ).not.toThrowError()
+
+      expect(() =>
+        factory.createMulti(['name', 'code'], ['type1', 'type2', 'type3?????'])
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Same number of types and keys must be provided"`
+      )
     })
   })
 })
@@ -186,20 +205,5 @@ describe(match, () => {
     expect(match('', '', true)).toBe(true)
     expect(match('a', 'asdf', true)).toBe(false)
     expect(match('a', 'AA', true)).toBe(false)
-  })
-
-  it('is resilient to non-matching types', () => {
-    // @ts-expect-error testing bad caller
-    expect(match(0, false)).toBe(false)
-    // @ts-expect-error testing bad caller
-    expect(match(null, 0)).toBe(false)
-    // @ts-expect-error testing bad caller
-    expect(match('', null)).toBe(false)
-    // @ts-expect-error testing bad caller
-    expect(match(false, '')).toBe(false)
-    // @ts-expect-error testing bad caller
-    expect(match(0, '')).toBe(false)
-    // @ts-expect-error testing bad caller
-    expect(match(false, '', true)).toBe(false)
   })
 })

--- a/src/datasource/__tests__/queries.test.ts
+++ b/src/datasource/__tests__/queries.test.ts
@@ -409,5 +409,20 @@ describe(QueryBuilder, () => {
         ).toMatchSnapshot()
       })
     })
+
+    describe('multiColumnBatchGet', () => {
+      it('builds the query correctly', () => {
+        expect(
+          builder.multiColumnBatchGet(
+            [
+              { id: 1, name: 'asdf' },
+              { id: 2, name: 'blah' },
+            ],
+            ['id', 'name'],
+            ['integer', 'text']
+          )
+        ).toMatchSnapshot()
+      })
+    })
   })
 })

--- a/src/datasource/loaders/LoaderFactory.ts
+++ b/src/datasource/loaders/LoaderFactory.ts
@@ -148,10 +148,9 @@ export default class LoaderFactory<TRowType> {
     TColumnNames extends Array<
       SearchableKeys<TRowType> & keyof TRowType & string
     >,
-    TBatchKey extends Record<
-      TColumnNames[0],
-      TRowType[TColumnNames[0] & (string | number)]
-    >
+    TBatchKey extends {
+      [K in TColumnNames[0]]: TRowType[K]
+    }
   >(
     keys: TColumnNames,
     columnTypes?: string[] | LoaderOptions<TRowType, true>,
@@ -184,7 +183,12 @@ export default class LoaderFactory<TRowType> {
       string
     >(
       async (args: readonly TBatchKey[]) => {
-        const data = await getData<TColumnNames>(args, keys, types, options)
+        const data = await getData<TColumnNames, TBatchKey>(
+          args,
+          keys,
+          types,
+          options
+        )
         callbackFn && data.forEach(callbackFn)
         return args.map((batchKey) => {
           const callback = (row: TRowType) => {

--- a/src/datasource/loaders/types.ts
+++ b/src/datasource/loaders/types.ts
@@ -13,18 +13,29 @@ export interface GetDataFunction<TRowType> {
   ): readonly TRowType[] | Promise<readonly TRowType[]>
 }
 
+export interface GetDataMultiFunction<TRowType> {
+  <TColumnNames extends Array<keyof TRowType & string>>(
+    args:
+      | Array<Record<TColumnNames[0], TRowType[TColumnNames[0]]>>
+      | ReadonlyArray<Record<TColumnNames[0], TRowType[TColumnNames[0]]>>,
+    columns: TColumnNames,
+    types: string[],
+    options?: QueryOptions<TRowType>
+  ): readonly TRowType[] | Promise<readonly TRowType[]>
+}
+
 export interface LoaderFactoryOptions<TRowType> {
   columnToKey?: (column: string) => string
   keyToColumn?: (column: string) => string
   columnTypes: Record<keyof TRowType, string>
 }
 
-export type LoaderOptions<TRowType, TColumnName extends keyof TRowType> = {
-  getData?: GetDataFunction<TRowType>
+export type LoaderOptions<TRowType, IsMulti extends boolean = false> = {
+  getData?: IsMulti extends true
+    ? GetDataMultiFunction<TRowType>
+    : GetDataFunction<TRowType>
   multi?: boolean
-  ignoreCase?: TRowType extends Record<TColumnName, string>
-    ? boolean
-    : false | undefined
+  ignoreCase?: boolean
   callbackFn?: (
     row: TRowType,
     index: number,

--- a/src/datasource/loaders/types.ts
+++ b/src/datasource/loaders/types.ts
@@ -14,10 +14,11 @@ export interface GetDataFunction<TRowType> {
 }
 
 export interface GetDataMultiFunction<TRowType> {
-  <TColumnNames extends Array<keyof TRowType & string>>(
-    args:
-      | Array<Record<TColumnNames[0], TRowType[TColumnNames[0]]>>
-      | ReadonlyArray<Record<TColumnNames[0], TRowType[TColumnNames[0]]>>,
+  <
+    TColumnNames extends Array<keyof TRowType & string>,
+    TArgs extends { [K in TColumnNames[0]]: TRowType[K] }
+  >(
+    args: Array<TArgs> | ReadonlyArray<TArgs>,
     columns: TColumnNames,
     types: string[],
     options?: QueryOptions<TRowType>

--- a/src/datasource/loaders/utils.ts
+++ b/src/datasource/loaders/utils.ts
@@ -1,6 +1,6 @@
-export const match = <T extends string | number>(
-  left: T,
-  right: T,
+export const match = (
+  left: unknown,
+  right: unknown,
   ignoreCase = false
 ): boolean => {
   if (typeof left === 'string' && typeof right === 'string' && ignoreCase) {

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -537,12 +537,9 @@ export default class QueryBuilder<
     args: ReadonlyArray<Partial<TRowType>>
   ): SqlSqlToken {
     return sql`
-      LATERAL (
-        SELECT *
-        FROM json_populate_recordset(
-          null::${this.identifier()},
-          ${sql.json(args as unknown as SerializableValue)}
-        )
+      json_populate_recordset(
+        null::${this.identifier()},
+        ${sql.json(args as unknown as SerializableValue)}
       ) AS ${this.identifier(`${this.table}_${CONDITIONS_TABLE}`, false)}
     `
   }

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -1,5 +1,6 @@
 import {
   IdentifierSqlToken,
+  SerializableValue,
   sql,
   SqlSqlToken,
   SqlToken,
@@ -36,6 +37,7 @@ export interface SelectOptions {
 
 const EMPTY = sql``
 const noop = (v: string): string => v
+const CONDITIONS_TABLE = 'conditions'
 
 export default class QueryBuilder<
   TRowType,
@@ -59,10 +61,17 @@ export default class QueryBuilder<
     }
   }
 
-  public identifier(column?: string, includeTable = true): IdentifierSqlToken {
+  public identifier(
+    column?: string,
+    includeTable: boolean | string = true
+  ): IdentifierSqlToken {
     const names = []
 
-    includeTable && names.push(this.table)
+    if (typeof includeTable === 'string') {
+      names.push(includeTable)
+    } else if (includeTable) {
+      names.push(this.table)
+    }
     column !== undefined && names.push(this.columnCase(column))
 
     return sql.identifier(names)
@@ -501,6 +510,60 @@ export default class QueryBuilder<
       }
       return column
     })
+  }
+
+  public multiColumnBatchGet<
+    TColumnNames extends Array<keyof TRowType & string>
+  >(
+    args: ReadonlyArray<Record<TColumnNames[0], TRowType[TColumnNames[0]]>>,
+    columns: TColumnNames,
+    types: string[],
+    options?: QueryOptions<TRowType> & SelectOptions
+  ): TaggedTemplateLiteralInvocation<TRowType> {
+    options = this.getOptions(options)
+    return sql`
+      SELECT ${this.identifier()}.*
+      FROM ${this.identifier()},
+      ${this.jsonRowComparison(args as ReadonlyArray<Partial<TRowType>>)}
+      WHERE ${this.columnConditionsMap(columns, types)}
+      ${options.groupBy ? this.groupBy(options.groupBy) : EMPTY}
+      ${options.orderBy ? this.orderBy(options.orderBy) : EMPTY}
+      ${options.limit ? this.limit(options.limit) : EMPTY}
+      ${options.forUpdate ? this.forUpdate(options.forUpdate) : EMPTY}
+    `
+  }
+
+  private jsonRowComparison(
+    args: ReadonlyArray<Partial<TRowType>>
+  ): SqlSqlToken {
+    return sql`
+      LATERAL (
+        SELECT *
+        FROM json_populate_recordset(
+          null::${this.identifier()},
+          ${sql.json(args as unknown as SerializableValue)}
+        )
+      ) AS ${this.identifier(`${this.table}_${CONDITIONS_TABLE}`, false)}
+    `
+  }
+
+  private columnConditionsMap(
+    columns: Array<keyof TRowType & string>,
+    types: string[]
+  ): SqlSqlToken {
+    return sql`${sql.join(
+      columns.map((columnName, idx) => {
+        const tableColumn = this.identifier(columnName)
+        const conditionsColumn = this.identifier(
+          columnName,
+          `${this.table}_${CONDITIONS_TABLE}`
+        )
+        const type = this.identifier(types[idx], false)
+
+        return sql`${tableColumn}::${type} = ${conditionsColumn}::${type}`
+      }),
+      sql` AND `
+    )}`
   }
 
   private convertColumnEntry(


### PR DESCRIPTION
This change introduces a new `LoaderFactory` method `createMulti()`, which allows you to create loaders based on multiple columns.

Previously, loaders could only be created with a single column. This was primarily due to the difficulty of creating a generalizable query with a stable number of parameters (i.e. the parameterized query always has a number of parameters that does not depend on the number of arguments given to the batch data fetching function).

I have now identified a method of doing that in a parameter-stable way via the `json_populate_recordset` function in PostgreSQL.

`LoaderFactory.createMulti()` may, at some point, be merged into `LoaderFactory.create()` if I can figure out how to untangle the types.