### PR TITLE
Transaction support

### DIFF
--- a/src/datasource/loaders/LoaderFactory.ts
+++ b/src/datasource/loaders/LoaderFactory.ts
@@ -128,7 +128,7 @@ export default class LoaderFactory<TRowType> {
       TColType,
       TRowType[] | (TRowType | undefined)
     >(async (args: readonly TColType[]) => {
-      const data = await getData<TColumnName>(args, key, type, options)
+      const data = await getData<TColumnName>(args, key, type, loader, options)
 
       data.forEach((row, idx, arr) => {
         callbackFn && callbackFn(row, idx, arr)
@@ -264,6 +264,7 @@ export default class LoaderFactory<TRowType> {
           args,
           keys,
           types,
+          loader,
           options
         )
 

--- a/src/datasource/loaders/types.ts
+++ b/src/datasource/loaders/types.ts
@@ -10,6 +10,10 @@ export interface GetDataFunction<TRowType> {
     args: Array<TRowType[TColumnName]> | ReadonlyArray<TRowType[TColumnName]>,
     column: TColumnName,
     type: string,
+    loader: DataLoader<
+      TRowType[TColumnName] & (string | number),
+      TRowType[] | (TRowType | undefined)
+    >,
     options?: QueryOptions<TRowType>
   ): readonly TRowType[] | Promise<readonly TRowType[]>
 }
@@ -22,6 +26,7 @@ export interface GetDataMultiFunction<TRowType> {
     args: Array<TArgs> | ReadonlyArray<TArgs>,
     columns: TColumnNames,
     types: string[],
+    loader: DataLoader<TArgs, TRowType[] | (TRowType | undefined)>,
     options?: QueryOptions<TRowType>
   ): readonly TRowType[] | Promise<readonly TRowType[]>
 }


### PR DESCRIPTION
Adds rudimentary transaction support to DBDataSource

Previously, no support for transactions was available, leading to DBDS only being able to be used for simplistic use-cases.

Adds a public `transaction` method to DBDataSource instances which will start execute a given callback within the context of a transaction. That transaction will apply to all DBDataSource instances with the same database pool.

Unfortunately, the API is a little bit strange -- you can start the transaction on any instance, and then use any other instance within it. It could possibly be nice to pull out all of that handling into some kind of transaction manager, but for now we're sticking with this simple implementation, as it works as expected.

That said, be careful with loader cache priming -- any _new_ lookups performed within the transaction will be cleared from the cache, but any manual priming that is done (e.g. after running an insert or update) will not be automatically cleared.