### PR TITLE
Fix insertion of a single empty object

### DIFF
--- a/src/datasource/__tests__/singleemptyobjectinsert.test.ts
+++ b/src/datasource/__tests__/singleemptyobjectinsert.test.ts
@@ -1,0 +1,107 @@
+import assert from 'assert'
+import { createPool, DatabasePool, sql } from 'slonik'
+import { z } from 'zod'
+
+import { DBDataSource } from '..'
+
+const DummyMetadata = {
+  id: {
+    nativeType: 'int8',
+    nativeName: 'id',
+  },
+}
+
+const Dummy$SelectSchema = z.object({
+  id: z.number(),
+})
+
+const Dummy$InsertSchema = z.object({
+  id: z.number().optional(),
+})
+
+let pool: DatabasePool
+
+beforeAll(async () => {
+  assert(process.env.DATABASE_URL, 'DATABASE_URL must be configured')
+
+  pool = await createPool(process.env.DATABASE_URL, {
+    captureStackTrace: true,
+    maximumPoolSize: 1,
+    idleTimeout: 'DISABLE_TIMEOUT',
+    idleInTransactionSessionTimeout: 'DISABLE_TIMEOUT',
+  })
+
+  await pool.transaction(async (connection) => {
+    await connection.query(sql.unsafe`
+      CREATE EXTENSION IF NOT EXISTS citext
+    `)
+    await connection.query(sql.unsafe`
+      CREATE TABLE IF NOT EXISTS "empty_object_test_table" (
+        "id" SERIAL PRIMARY KEY
+      )
+    `)
+  })
+})
+
+class TestDataSource extends DBDataSource<{
+  name: 'empty_object_test_table'
+  metadata: typeof DummyMetadata
+  schemas: {
+    select: z.ZodObject<
+      typeof Dummy$SelectSchema['shape'],
+      'strip',
+      z.ZodTypeAny
+    >
+    insert: z.ZodObject<
+      typeof Dummy$InsertSchema['shape'],
+      'strip',
+      z.ZodTypeAny
+    >
+    update: z.ZodObject<{
+      [k in keyof typeof Dummy$InsertSchema['shape']]: z.ZodOptional<
+        typeof Dummy$InsertSchema['shape'][k]
+      >
+    }>
+  }
+}> {
+  constructor() {
+    const schema$select = Dummy$SelectSchema
+    const schema$insert = Dummy$InsertSchema
+
+    super(pool, {
+      name: 'empty_object_test_table',
+      metadata: DummyMetadata,
+      schemas: {
+        select: schema$select,
+        insert: schema$insert,
+        update: schema$insert.partial(),
+      },
+    })
+  }
+
+  public idLoader = this.loaders.create('id')
+
+  // these functions are protected, so we're not normally able to access them
+  public testInsert: TestDataSource['insert'] = this.insert
+}
+
+let ds: TestDataSource
+
+beforeEach(() => {
+  ds = new TestDataSource()
+})
+
+afterEach(async () => {
+  await pool.query(sql.unsafe`TRUNCATE empty_object_test_table`)
+})
+
+afterAll(async () => {
+  await pool.end()
+})
+
+describe('DBDataSource', () => {
+  it('can insert row with no column specified', async () => {
+    const result = await ds.testInsert({})
+    expect(result).toMatchObject({ id: expect.any(Number) })
+  })
+})

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -690,7 +690,11 @@ export default class QueryBuilder<Info extends TableInfo> {
   }
 
   private isEmptyObject(value: unknown): boolean {
-    return typeof value === 'object' && value !== null && Object.keys(value).length === 0
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      Object.keys(value).length === 0
+    )
   }
 
   private valueToSql(

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -690,7 +690,7 @@ export default class QueryBuilder<Info extends TableInfo> {
   }
 
   private isEmptyObject(value: unknown): boolean {
-    return typeof value === 'object' && Object.keys(value).length === 0
+    return typeof value === 'object' && value !== null && Object.keys(value).length === 0
   }
 
   private valueToSql(

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -136,10 +136,14 @@ export default class QueryBuilder<Info extends TableInfo> {
   ) {
     options = this.getOptions(options)
 
-    // special case: we're given a single empty row...
+    // special case: we're given a single empty row or an array with one entry
+    // that is an empty row
     // unfortunately i don't *think* we can do this if we're given numerous
     // empty rows.
-    if (typeof rows === 'object' && Object.keys(rows).length === 0) {
+    if (
+      this.isEmptyObject(rows) ||
+      (Array.isArray(rows) && rows.length === 1 && this.isEmptyObject(rows[0]))
+    ) {
       return this.insertDefaultValues(options)
     }
 
@@ -683,6 +687,10 @@ export default class QueryBuilder<Info extends TableInfo> {
 
   private isNullable(array: unknown[]): boolean {
     return array.some((v): v is null => v === null)
+  }
+
+  private isEmptyObject(value: any): boolean {
+    return typeof value === 'object' && Object.keys(value).length === 0
   }
 
   private valueToSql(

--- a/src/datasource/queries/QueryBuilder.ts
+++ b/src/datasource/queries/QueryBuilder.ts
@@ -689,7 +689,7 @@ export default class QueryBuilder<Info extends TableInfo> {
     return array.some((v): v is null => v === null)
   }
 
-  private isEmptyObject(value: any): boolean {
+  private isEmptyObject(value: unknown): boolean {
     return typeof value === 'object' && Object.keys(value).length === 0
   }
 


### PR DESCRIPTION
[This change](https://github.com/ProjectXero/dbds/commit/d3d216605885b43776ec04c7b3903d328b0135e3#diff-3e5f060a4157ac55960ff312a74818a9a416adaab4664a1148317b2f2ddafb67R369-R372) results in `[{}]` being passed to `QueryBuilder.insert` instead of `{}`, and the former is not handled by the special case logic for inserting default values. This PR add support for that case in the special case logic